### PR TITLE
Writing ApplicationError derive macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ repository = "https://github.com/BeringLab/event-driven-library"
 [dependencies]
 event-driven-core= {version="0.1.13", path="./event-driven-core"}
 event-driven-macro= {version="0.1.10", path="./event-driven-macro"}
+static_assertions="1.1.0"

--- a/event-driven-core/src/messagebus.rs
+++ b/event-driven-core/src/messagebus.rs
@@ -68,9 +68,7 @@ where
 
 					if let Err(err) = self.handle_event(msg, context_manager.clone()).await {
 						// ! Safety:: BaseError Must Be Enforced To Be Accepted As Variant On ServiceError
-						if let "EventNotFound" = err.to_string().as_str() {
-							continue;
-						}
+						eprintln!("{:?}", err);
 					}
 				}
 				Err(TryRecvError::Empty) => {

--- a/event-driven-core/src/messagebus.rs
+++ b/event-driven-core/src/messagebus.rs
@@ -34,12 +34,11 @@ pub struct MessageBus<R: ApplicationResponse, E: ApplicationError> {
 	command_handler: &'static TCommandHandler<R, E>,
 	event_handler: &'static TEventHandler<R, E>,
 }
-
+// BaseError: From<services::response::ServiceError>`
 impl<R, E> MessageBus<R, E>
 where
 	R: ApplicationResponse,
-	E: ApplicationError + std::convert::From<crate::responses::BaseError>,
-	BaseError: std::convert::From<E>,
+	E: ApplicationError + std::convert::From<crate::responses::BaseError> + std::convert::Into<crate::responses::BaseError>,
 {
 	pub fn new(command_handler: &'static TCommandHandler<R, E>, event_handler: &'static TEventHandler<R, E>) -> Arc<Self> {
 		Self { command_handler, event_handler }.into()

--- a/event-driven-core/src/responses.rs
+++ b/event-driven-core/src/responses.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt::Display};
+use std::error;
 
 use crate::prelude::Message;
 
@@ -15,24 +15,9 @@ pub enum BaseError {
 	ServiceError(Box<AnyError>),
 }
 
-impl std::error::Error for BaseError {}
-impl Display for BaseError {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		match self {
-			BaseError::CommandNotFound => write!(f, "CommandNotFound"),
-			BaseError::EventNotFound => write!(f, "EventNotFound"),
-			BaseError::StopSentinel => write!(f, "StopSentinel"),
-			BaseError::StopSentinelWithEvent(_message) => write!(f, "StopSentinel"),
-			BaseError::DatabaseError(res) => write!(f, "{}", res),
-			BaseError::ServiceError(_) => write!(f, "ServiceError"),
-			BaseError::TransactionError => write!(f, "TransactionError"),
-		}
-	}
-}
-
 pub trait ApplicationResponse: 'static {}
 
-pub trait ApplicationError: std::error::Error + 'static {}
+pub trait ApplicationError: 'static + std::fmt::Debug {}
 impl ApplicationError for BaseError {}
 
 impl From<BaseError> for Box<dyn ApplicationError> {

--- a/event-driven-macro/src/error.rs
+++ b/event-driven-macro/src/error.rs
@@ -2,25 +2,38 @@ use proc_macro::TokenStream;
 use syn::DeriveInput;
 
 pub(crate) fn render_error_token(ast: &DeriveInput) -> TokenStream {
+	// Forcing target to be enum
+	match ast.data {
+		syn::Data::Enum(_) => {}
+		_ => {
+			panic!("#[derive(ApplicationError)] is only support enum.")
+		}
+	}
+
 	let name = &ast.ident;
+	let crates = ast.attrs.iter().find(|x| x.path().is_ident("crates"));
+	let crates = if let Some(crates) = crates {
+		crates.parse_args::<syn::ExprPath>().unwrap().path.get_ident().expect("#[crates(...)] expects path.").to_string()
+	} else {
+		"event_driven_library".to_owned()
+	};
+	let crates = syn::Ident::new(&crates, proc_macro2::Span::call_site());
+	let error_with_event = ast.attrs.iter().find(|x| x.path().is_ident("error_with_event"));
+	let database_error = ast.attrs.iter().find(|x| x.path().is_ident("database_error"));
+	let service_error = ast.attrs.iter().find(|x| x.path().is_ident("service_error"));
 
 	quote!(
-
-		impl std::error::Error for #name {}
-		impl ApplicationError for #name {}
-		impl From<BaseError> for #name {
-			fn from(value: BaseError) -> Self {
-				#name::BaseError(value)
+		impl ::std::error::Error for #name {}
+		impl #crates::event_driven_core::responses::ApplicationError for #name {}
+		impl ::std::convert::From<#crates::event_driven_core::responses::BaseError> for #name {
+			fn from(value: #crates::event_driven_core::responses::BaseError) -> Self {
+				// #name::BaseError(value)
+				todo!()
 			}
 		}
-		impl From<std::boxed::Box<#name>> for std::boxed::Box<dyn ApplicationError> {
-			fn from(value: std::boxed::Box<#name>) -> Self {
-				value
-			}
-		}
-		impl From<#name> for std::boxed::Box<dyn ApplicationError> {
-			fn from(value: #name) -> Self {
-				std::boxed::Box::new(value)
+		impl ::std::convert::Into<::std::boxed::Box<dyn #crates::event_driven_core::responses::ApplicationError>> for #name {
+			fn into(self) -> ::std::boxed::Box<dyn #crates::event_driven_core::responses::ApplicationError> {
+				::std::boxed::Box::new(self)
 			}
 		}
 	)

--- a/event-driven-macro/src/error.rs
+++ b/event-driven-macro/src/error.rs
@@ -3,14 +3,17 @@ use syn::DeriveInput;
 
 pub(crate) fn render_error_token(ast: &DeriveInput) -> TokenStream {
 	// Forcing target to be enum
-	match ast.data {
-		syn::Data::Enum(_) => {}
+	let data = match &ast.data {
+		syn::Data::Enum(data) => data,
 		_ => {
 			panic!("#[derive(ApplicationError)] is only support enum.")
 		}
-	}
+	};
 
 	let name = &ast.ident;
+	let find_variant = |name: &str| data.variants.iter().find(|x| x.attrs.iter().find(|x| x.path().is_ident(name)).is_some());
+
+	/* \#\[crates(...)\] */
 	let crates = ast.attrs.iter().find(|x| x.path().is_ident("crates"));
 	let crates = if let Some(crates) = crates {
 		crates.parse_args::<syn::ExprPath>().unwrap().path.get_ident().expect("#[crates(...)] expects path.").to_string()
@@ -18,21 +21,70 @@ pub(crate) fn render_error_token(ast: &DeriveInput) -> TokenStream {
 		"event_driven_library".to_owned()
 	};
 	let crates = syn::Ident::new(&crates, proc_macro2::Span::call_site());
-	let error_with_event = ast.attrs.iter().find(|x| x.path().is_ident("error_with_event"));
-	let database_error = ast.attrs.iter().find(|x| x.path().is_ident("database_error"));
-	let service_error = ast.attrs.iter().find(|x| x.path().is_ident("service_error"));
+
+	/* \#\[error\] */
+	let error = find_variant("error");
+	if let Some(error) = error {
+		if let syn::Fields::Unit = error.fields {
+		} else {
+			panic!("#[error] expects unit.")
+		}
+	}
+	let error = if let Some(error) = error {
+		error.ident.clone()
+	} else {
+		syn::Ident::new("StopSentinel", proc_macro2::Span::call_site())
+	};
+
+	/* \#\[error_with_event\] */
+	let error_with_event = find_variant("error_with_event");
+	if let Some(error_with_event) = error_with_event {
+		if let syn::Fields::Unnamed(_) = error_with_event.fields {
+		} else {
+			panic!("#[error_with_event] expects Field(Box<AnyError>).")
+		}
+	}
+	let error_with_event = if let Some(error_with_event) = error_with_event {
+		error_with_event.ident.clone()
+	} else {
+		syn::Ident::new("StopSentinelWithEvent", proc_macro2::Span::call_site())
+	};
+
+	/* \#\[database_error\] */
+	let database_error = find_variant("database_error");
+	if let Some(database_error) = database_error {
+		if let syn::Fields::Unnamed(_) = database_error.fields {
+		} else {
+			panic!("#[database_error] expects Field(Box<AnyError>).")
+		}
+	}
+	let database_error = if let Some(database_error) = database_error {
+		database_error.ident.clone()
+	} else {
+		syn::Ident::new("DatabaseError", proc_macro2::Span::call_site())
+	};
 
 	quote!(
 		impl #crates::event_driven_core::responses::ApplicationError for #name {}
 		impl ::std::convert::From<#crates::event_driven_core::responses::BaseError> for #name {
 			fn from(value: #crates::event_driven_core::responses::BaseError) -> Self {
-				// #name::BaseError(value)
-				todo!()
+				match value {
+					#crates::event_driven_core::responses::BaseError::StopSentinel => Self::#error,
+					#crates::event_driven_core::responses::BaseError::StopSentinelWithEvent(event) => Self::#error_with_event(event),
+					#crates::event_driven_core::responses::BaseError::DatabaseError(error) => Self::#database_error(error),
+					_ => unimplemented!("BaseError to #name is only support for StopSentinel, StopSentinelWithEvent, DatabaseError."),
+				}
 			}
 		}
-		impl ::std::convert::Into<::std::boxed::Box<dyn #crates::event_driven_core::responses::ApplicationError>> for #name {
-			fn into(self) -> ::std::boxed::Box<dyn #crates::event_driven_core::responses::ApplicationError> {
-				::std::boxed::Box::new(self)
+		impl ::std::convert::Into<::std::boxed::Box<dyn  #crates::event_driven_core::responses::BaseError>> for #name {
+			fn into(self) -> ::std::boxed::Box<dyn  #crates::event_driven_core::responses::BaseError> {
+				let data = match self {
+					#name::#error => #crates::event_driven_core::responses::BaseError::StopSentinel,
+					#name::#error_with_event(event) => #crates::event_driven_core::responses::BaseError::StopSentinelWithEvent(event),
+					#name::#database_error(error) => #crates::event_driven_core::responses::BaseError::DatabaseError(error),
+					_ => #crates::event_driven_core::responses::BaseError::ServiceError(error),
+				};
+				::std::boxed::Box::new(data)
 			}
 		}
 	)

--- a/event-driven-macro/src/error.rs
+++ b/event-driven-macro/src/error.rs
@@ -23,7 +23,6 @@ pub(crate) fn render_error_token(ast: &DeriveInput) -> TokenStream {
 	let service_error = ast.attrs.iter().find(|x| x.path().is_ident("service_error"));
 
 	quote!(
-		impl ::std::error::Error for #name {}
 		impl #crates::event_driven_core::responses::ApplicationError for #name {}
 		impl ::std::convert::From<#crates::event_driven_core::responses::BaseError> for #name {
 			fn from(value: #crates::event_driven_core::responses::BaseError) -> Self {

--- a/event-driven-macro/src/lib.rs
+++ b/event-driven-macro/src/lib.rs
@@ -39,8 +39,21 @@ pub fn aggregate_derive(attr: TokenStream) -> TokenStream {
 /// - `#[error]` - Specify the error matching for `BaseError::StopSentinel`.
 /// - `#[error_with_event]` - Specify the error matching for `BaseError::StopSentinelWithEvent`.
 /// - `#[database_error]` - Specify the error matching for `BaseError::DatabaseError`.
-/// - `#[service_error]` - Specify the error matching for `BaseError::ServiceError`.
-#[proc_macro_derive(ApplicationError, attributes(error, error_with_event, database_error, service_error, crates))]
+///
+/// ## Example
+/// ```ignore
+/// #[derive(Debug, ApplicationError)]
+/// #[crates(crate::imports::event_driven_library)]
+/// enum TestError {
+///   #[error]
+///   Stop,
+///   #[error_with_event]
+///   StopWithEvent(Box<AnyError>),
+///   #[database_error]
+///   DatabaseError(Box<AnyError>),
+/// }
+/// ```
+#[proc_macro_derive(ApplicationError, attributes(error, error_with_event, database_error, crates))]
 pub fn error_derive(attr: TokenStream) -> TokenStream {
 	let ast: DeriveInput = syn::parse(attr).unwrap();
 

--- a/event-driven-macro/src/lib.rs
+++ b/event-driven-macro/src/lib.rs
@@ -53,7 +53,7 @@ pub fn aggregate_derive(attr: TokenStream) -> TokenStream {
 ///   DatabaseError(Box<AnyError>),
 /// }
 /// ```
-#[proc_macro_derive(ApplicationError, attributes(error, error_with_event, database_error, crates))]
+#[proc_macro_derive(ApplicationError, attributes(stop_sentinel, stop_sentinel_with_event, database_error, crates))]
 pub fn error_derive(attr: TokenStream) -> TokenStream {
 	let ast: DeriveInput = syn::parse(attr).unwrap();
 

--- a/event-driven-macro/src/lib.rs
+++ b/event-driven-macro/src/lib.rs
@@ -45,9 +45,9 @@ pub fn aggregate_derive(attr: TokenStream) -> TokenStream {
 /// #[derive(Debug, ApplicationError)]
 /// #[crates(crate::imports::event_driven_library)]
 /// enum TestError {
-///   #[error]
+///   #[stop_sentinel]
 ///   Stop,
-///   #[error_with_event]
+///   #[stop_sentinel_with_event]
 ///   StopWithEvent(Box<AnyError>),
 ///   #[database_error]
 ///   DatabaseError(Box<AnyError>),

--- a/event-driven-macro/src/lib.rs
+++ b/event-driven-macro/src/lib.rs
@@ -36,8 +36,8 @@ pub fn aggregate_derive(attr: TokenStream) -> TokenStream {
 /// ## Attributes
 ///
 /// - `#[crates(...)]` - Specify the name of root of event-driven-library crate. (Default is `event_driven_library`)
-/// - `#[error]` - Specify the error matching for `BaseError::StopSentinel`.
-/// - `#[error_with_event]` - Specify the error matching for `BaseError::StopSentinelWithEvent`.
+/// - `#[stop_sentinel]` - Specify the error matching for `BaseError::StopSentinel`.
+/// - `#[stop_sentinel_with_event]` - Specify the error matching for `BaseError::StopSentinelWithEvent`.
 /// - `#[database_error]` - Specify the error matching for `BaseError::DatabaseError`.
 ///
 /// ## Example

--- a/event-driven-macro/src/lib.rs
+++ b/event-driven-macro/src/lib.rs
@@ -29,7 +29,7 @@ pub fn aggregate_derive(attr: TokenStream) -> TokenStream {
 
 /// Define a Application Error type that can be used in the event-driven-library.
 ///
-/// Before deriving this, you must impl `Debug` and `Display` traits.
+/// Before deriving this, you must impl `Debug`traits.
 ///
 /// This macro can be only used in enum.
 ///

--- a/event-driven-macro/src/lib.rs
+++ b/event-driven-macro/src/lib.rs
@@ -27,9 +27,22 @@ pub fn aggregate_derive(attr: TokenStream) -> TokenStream {
 	render_aggregate_token(&ast)
 }
 
-#[proc_macro_derive(ApplicationError)]
+/// Define a Application Error type that can be used in the event-driven-library.
+///
+/// Before deriving this, you must impl `Debug` and `Display` traits.
+///
+/// This macro can be only used in enum.
+///
+/// ## Attributes
+///
+/// - `#[crates(...)]` - Specify the name of root of event-driven-library crate. (Default is `event_driven_library`)
+/// - `#[error]` - Specify the error matching for `BaseError::StopSentinel`.
+/// - `#[error_with_event]` - Specify the error matching for `BaseError::StopSentinelWithEvent`.
+/// - `#[database_error]` - Specify the error matching for `BaseError::DatabaseError`.
+/// - `#[service_error]` - Specify the error matching for `BaseError::ServiceError`.
+#[proc_macro_derive(ApplicationError, attributes(error, error_with_event, database_error, service_error, crates))]
 pub fn error_derive(attr: TokenStream) -> TokenStream {
-	let ast: DeriveInput = syn::parse(attr.clone()).unwrap();
+	let ast: DeriveInput = syn::parse(attr).unwrap();
 
 	error::render_error_token(&ast)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,7 @@
 
 pub extern crate event_driven_core;
 pub extern crate event_driven_macro;
+pub extern crate static_assertions;
 
 pub mod prelude {
 	pub use event_driven_core::convert_event;
@@ -257,9 +258,7 @@ mod application_error_derive_test {
 	#[derive(Debug, ApplicationError)]
 	#[crates(event_driven_library)]
 	enum Err {
-		#[error]
+		#[stop_sentinel]
 		Items,
-		#[error_with_event]
-		Items2,
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,7 +252,11 @@ mod dependency_test {
 
 #[cfg(test)]
 mod application_error_derive_test {
+	use std::fmt::Display;
+
 	use crate as event_driven_library;
+	use event_driven_core::message::Message;
+	use event_driven_core::responses::AnyError;
 	use event_driven_macro::ApplicationError;
 
 	#[derive(Debug, ApplicationError)]
@@ -260,5 +264,19 @@ mod application_error_derive_test {
 	enum Err {
 		#[stop_sentinel]
 		Items,
+		#[stop_sentinel_with_event]
+		StopSentinelWithEvent(Box<dyn Message>),
+		#[database_error]
+		DatabaseError(Box<AnyError>),
+	}
+
+	impl Display for Err {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			match self {
+				Self::Items => write!(f, "items"),
+				Self::StopSentinelWithEvent(item) => write!(f, "{:?}", item),
+				Self::DatabaseError(err) => write!(f, "{}", err),
+			}
+		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,8 +211,8 @@
 //!
 //!
 
-extern crate event_driven_core;
-extern crate event_driven_macro;
+pub extern crate event_driven_core;
+pub extern crate event_driven_macro;
 
 pub mod prelude {
 	pub use event_driven_core::convert_event;
@@ -249,5 +249,26 @@ mod dependency_test {
 	fn test() -> i32 {
 		let _ = "hello";
 		0
+	}
+}
+
+#[cfg(test)]
+mod application_error_derive_test {
+	use crate as event_driven_library;
+	use event_driven_macro::ApplicationError;
+	use std::fmt::Display;
+
+	#[derive(Debug, ApplicationError)]
+	#[crates(event_driven_library)]
+	enum Err {
+		#[error]
+		Items,
+		#[error_with_event]
+		Items2,
+	}
+	impl Display for Err {
+		fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			unimplemented!()
+		}
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@
 //! * context - [AtomicContextManager]
 //!
 //! ### Example
-//! ```
+//! ```ignore
 //! pub async fn make_order(
 //!     cmd: MakeOrder,
 //!     context: AtomicContextManager,
@@ -132,11 +132,10 @@
 //!
 //!     Ok(().into())
 //! }
-//!
 //! ```
 //! But sometimes, you may want to add yet another dependencies. For that, Dependency Injection mechanism has been implemented.
 //! So, you can also do something along the lines of:
-//! ```
+//! ```ignore
 //! pub async fn make_order(
 //!     cmd: MakeOrder,
 //!     context: AtomicContextManager,
@@ -208,8 +207,6 @@
 //! #### Error from MessageBus
 //! When command has not yet been regitered, it returns an error - `BaseError::CommandNotFound`
 //! Be mindful that bus does NOT return the result of event processing as in distributed event processing.
-//!
-//!
 
 pub extern crate event_driven_core;
 pub extern crate event_driven_macro;
@@ -256,7 +253,6 @@ mod dependency_test {
 mod application_error_derive_test {
 	use crate as event_driven_library;
 	use event_driven_macro::ApplicationError;
-	use std::fmt::Display;
 
 	#[derive(Debug, ApplicationError)]
 	#[crates(event_driven_library)]
@@ -265,10 +261,5 @@ mod application_error_derive_test {
 		Items,
 		#[error_with_event]
 		Items2,
-	}
-	impl Display for Err {
-		fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-			unimplemented!()
-		}
 	}
 }


### PR DESCRIPTION
For now, it wouldn't compile cause it was pretended to `BaseError::ServiceError` takes origin error type